### PR TITLE
Validations when DIG response is not expected

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -21,6 +21,14 @@ function parse(output = '') {
   const result = {};
   const data = output.split(/\r?\n/);
   let section = 'header';
+  if(data.length<6) {
+    console.log(data);
+    //var msg = data[data.length-1];
+    //if (!msg || msg.length<=1) {
+    //  msg = output;
+    //}
+    throw new Error(output);
+  }
   data.forEach((line, i) => {
     let m;
     let changed = false;
@@ -65,10 +73,15 @@ const dig = function dig(args = [], options = {}) {
     });
 
     process.stdout.on('end', () => {
-      const result = (raw !== true) ?
-        parse(shellOutput) :
-        shellOutput.replace(/\n$/, '');
-      resolve(result);
+      try {
+        const result = (raw !== true) ?
+          parse(shellOutput) :
+          shellOutput.replace(/\n$/, '');
+        resolve(result);
+      } catch(ex) {
+        reject(ex);
+      }
+
     });
   });
 };

--- a/src/index.js
+++ b/src/index.js
@@ -21,13 +21,13 @@ function parse(output = '') {
   const result = {};
   const data = output.split(/\r?\n/);
   let section = 'header';
-  if(data.length<6) {
-    console.log(data);
-    //var msg = data[data.length-1];
-    //if (!msg || msg.length<=1) {
-    //  msg = output;
-    //}
-    throw new Error(output);
+  if (data.length < 6) {
+    // console.log('D:', data);
+    let msg = data[data.length - 2];
+    if (!msg || msg.length <= 1) {
+      msg = output;
+    }
+    throw new Error(msg);
   }
   data.forEach((line, i) => {
     let m;

--- a/test/index.js
+++ b/test/index.js
@@ -3,7 +3,7 @@ import dig from '../src/index';
 
 const expect = chai.expect;
 
-describe('Query DNS Server', () => {
+describe('Query DNS Server', function(done){
   it('Query ANY for google.com and parse output to JSON', (done) => {
     dig(['google.com', 'ANY'])
       .then((result) => {
@@ -74,5 +74,18 @@ describe('Query DNS Server', () => {
       .catch((err) => {
         console.log('Error:', err);
       });
+  });
+
+  this.timeout(20000);
+  it('DIG an unreachable host and throw exception', (done) => {
+    // https://serverfault.com/questions/776049/how-to-simulate-dns-server-response-timeout#answer-776191
+    dig(['example.com', '@72.66.115.13']).then((result) => {
+      expect(result).to.be.empty();
+      done(false);
+    }).catch((err) => {
+      // console.error(err);
+      expect(err.message).to.be.an('string');
+      done();
+    });
   });
 });


### PR DESCRIPTION
When DIG response is something different like a timeout error or something else, the response should validated before try to access to the array data in fixed positions.
I have added this validations and reject the response in case of this kind of errors.
Also added the respective test!